### PR TITLE
Add supervised models for Quality Estimation

### DIFF
--- a/models/prod/encs/qualityModel.encs.bin.gz
+++ b/models/prod/encs/qualityModel.encs.bin.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7f8da423effcf293c0acd49ce979ec61ceefc34fa6c462943c33e04da63f754
+size 108

--- a/models/prod/enes/qualityModel.enes.bin.gz
+++ b/models/prod/enes/qualityModel.enes.bin.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49aa82425f2616139896020b2d88a28dd5e9b9367ebcc8023007b887c63a7c27
+size 108

--- a/models/prod/enet/qualityModel.enet.bin.gz
+++ b/models/prod/enet/qualityModel.enet.bin.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:301932cbf4e105c92fabfa06b2f27b482f748f775eb6303fc83cfc5d5056b486
+size 108

--- a/registry.json
+++ b/registry.json
@@ -106,6 +106,13 @@
       "expectedSha256Hash": "e19c77231bf977988e31ff8db15fe79966b5170564bd3e10613f239e7f461d97",
       "modelType": "prod"
     },
+    "qualityModel": {
+      "name": "qualityModel.encs.bin",
+      "size": 68,
+      "estimatedCompressedSize": 108,
+      "expectedSha256Hash": "d7eba90036a065e4a1e93e889befe09f93a7d9a3417f3edffdb09a0db88fe83a",
+      "modelType": "prod"
+    },
     "vocab": {
       "name": "vocab.csen.spm",
       "size": 769763,
@@ -158,6 +165,13 @@
       "estimatedCompressedSize": 414566,
       "expectedSha256Hash": "909b1eea1face0d7f90a474fe29a8c0fef8d104b6e41e65616f864c964ba8845",
       "modelType": "prod"
+    },
+    "qualityModel": {
+      "name": "qualityModel.enes.bin",
+      "size": 68,
+      "estimatedCompressedSize": 108,
+      "expectedSha256Hash": "ce141f8e9e50a5ef4d8e3243a274b1734dc532f6963794a8869dce35acb543c2",
+      "modelType": "prod"
     }
   },
   "enet": {
@@ -180,6 +194,13 @@
       "size": 828426,
       "estimatedCompressedSize": 416995,
       "expectedSha256Hash": "e3b66bc141f6123cd40746e2fb9b8ee4f89cbf324ab27d6bbf3782e52f15fa2d",
+      "modelType": "prod"
+    },
+    "qualityModel": {
+      "name": "qualityModel.enet.bin",
+      "size": 68,
+      "estimatedCompressedSize": 108,
+      "expectedSha256Hash": "bb9b9c449c705297fe6b83542d64406201960971f102787b9b6c733416406707",
       "modelType": "prod"
     }
   },

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -1,7 +1,7 @@
 import gzip, json, sys, glob, os, hashlib
 
 # prod or all
-KEYS = ['model', 'vocab', 'lex']
+KEYS = ['model', 'vocab', 'lex', 'qualityModel']
 
 
 def get_meta(model_path, model_type):


### PR DESCRIPTION
Fixes https://github.com/mozilla/firefox-translations-models/issues/37
- Modified registry generation script to automatically generate registry for supervised models for Quality Estimation
- Added 3 Models
    - [English-Czech](https://github.com/browsermt/quality-estimation/blob/master/model/csen/encs.quality.lr)
    - [English-Estonian](https://github.com/browsermt/quality-estimation/blob/master/model/eten/enet.quality.lr)
    - [English-Spanish](https://github.com/browsermt/quality-estimation/blob/master/model/esen/enes.quality.lr)