### PR TITLE
fixed the issue of Python CLI library not having uniform error outputs across platforms

### DIFF
--- a/tests/remote_settings/test_create.py
+++ b/tests/remote_settings/test_create.py
@@ -148,7 +148,7 @@ def test_create_command_invalid_server():
     assert result.returncode == INVALID_USE, f"The return code should be {INVALID_USE}"
     assert "" == result.stdout, "The standard output stream should be empty"
     assert (
-    "argument --server: invalid choice: 'invalid_server' (choose from dev, stage, prod)"
+    "argument --server: invalid choice: 'invalid_server'"
     in result.stderr
 )
 

--- a/tests/remote_settings/test_create.py
+++ b/tests/remote_settings/test_create.py
@@ -148,9 +148,9 @@ def test_create_command_invalid_server():
     assert result.returncode == INVALID_USE, f"The return code should be {INVALID_USE}"
     assert "" == result.stdout, "The standard output stream should be empty"
     assert (
-        "argument --server: invalid choice: 'invalid_server' (choose from 'dev', 'stage', 'prod')"
-        in result.stderr
-    )
+    "argument --server: invalid choice: 'invalid_server' (choose from dev, stage, prod)"
+    in result.stderr
+)
 
 
 def test_create_command_invalid_version():

--- a/tests/remote_settings/test_create.py
+++ b/tests/remote_settings/test_create.py
@@ -148,9 +148,9 @@ def test_create_command_invalid_server():
     assert result.returncode == INVALID_USE, f"The return code should be {INVALID_USE}"
     assert "" == result.stdout, "The standard output stream should be empty"
     assert (
-    "argument --server: invalid choice: 'invalid_server'"
-    in result.stderr
-)
+        "argument --server: invalid choice: 'invalid_server'"
+        in result.stderr
+    )
 
 
 def test_create_command_invalid_version():


### PR DESCRIPTION
Updated the assertion in test_create_command_invalid_server to maintain uniform error outputs across platforms