### PR TITLE
Do not consider architecture in duplicate-version check

### DIFF
--- a/remote_settings/subcommands/create/command.py
+++ b/remote_settings/subcommands/create/command.py
@@ -86,7 +86,6 @@ def is_duplicate_record(record, existing_records):
             and existing.get("version") == record.get("version")
             and existing.get("sourceLanguage") == record.get("sourceLanguage")
             and existing.get("targetLanguage") == record.get("targetLanguage")
-            and existing.get("architecture") == record.get("architecture")
             and existing.get("fileType") == record.get("fileType")
         ):
             return True

--- a/tests/remote_settings/create/test_create_local_server.py
+++ b/tests/remote_settings/create/test_create_local_server.py
@@ -644,7 +644,7 @@ def test_create_command_no_files_in_directory():
     assert "You may need to unzip" in result.stdout
 
 
-def test_create_command_duplicate_record():
+def test_create_command_duplicate_record_same_architecture():
     version_used = CreateCommand.next_available_version()
 
     result = (
@@ -665,6 +665,36 @@ def test_create_command_duplicate_record():
         .with_version(version_used)
         .with_path(MODEL_PATH)
         .with_architecture("tiny")
+        .run()
+    )
+    assert duplicate_result.returncode == ERROR
+    assert (
+        f"Record {MODEL_NAME} already exists with version {version_used}"
+        in duplicate_result.stderr
+    )
+
+
+def test_create_command_duplicate_record_different_architecture():
+    version_used = CreateCommand.next_available_version()
+
+    result = (
+        CreateCommand()
+        .with_server("local")
+        .with_next_minor_version()
+        .with_path(MODEL_PATH)
+        .with_architecture("base-memory")
+        .run()
+    )
+    assert result.returncode == SUCCESS
+    assert "" == result.stderr, "The standard error stream should be empty"
+
+    # Explicitly uses the stored version again
+    duplicate_result = (
+        CreateCommand()
+        .with_server("local")
+        .with_version(version_used)
+        .with_path(MODEL_PATH)
+        .with_architecture("base")
         .run()
     )
     assert duplicate_result.returncode == ERROR


### PR DESCRIPTION
The architecture was never supposed to be considered when looking for duplicate versions. I accidentally missed this in a previous code review, so I'm fixing it now.

This patch ensures that the duplicate version error will trigger even if the architectures do not match. 